### PR TITLE
Pocket Casts Plus

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -8,9 +8,12 @@
 
     function sendCommand(action) {
         chrome.tabs.query({
-            "url": "https://*.pocketcasts.com/web/*",
+            "url": "https://play.pocketcasts.com/*",
         }, function(tabs) {
-            chrome.tabs.sendMessage(tabs[0].id, { "action": action });
+            var tab = tabs[0];
+            if (tab && tab.id) {
+                chrome.tabs.sendMessage(tab.id, { "action": action });
+            }
         });
     }
 

--- a/src/background.js
+++ b/src/background.js
@@ -13,6 +13,8 @@
             var tab = tabs[0];
             if (tab && tab.id) {
                 chrome.tabs.sendMessage(tab.id, { "action": action });
+            } else {
+                chrome.tabs.create({url: "https://play.pocketcasts.com", active: true});
             }
         });
     }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 2,
-    "name": "Media key support for (Beta) Pocket Casts",
-    "version": "1.2.0",
-    "author": "Tobias Thyssen, John Taylor (Just added beta player support)",
+    "name": "Media key support for Pocket Casts",
+    "version": "1.2.1",
+    "author": "Tobias Thyssen, John Taylor (Active maintainer)",
     "description": "Control Pocket Casts podcast webapp from anywhere!",
 
     "icons": {
@@ -11,8 +11,7 @@
 
     "permissions": [
         "tabs",
-        "https://play.pocketcasts.com/*",
-        "https://playbeta.pocketcasts.com/*"
+        "https://play.pocketcasts.com/*"
     ],
 
     "background": {
@@ -21,7 +20,7 @@
     },
 
     "content_scripts": [{
-        "matches": ["https://play.pocketcasts.com/*", "https://playbeta.pocketcasts.com/*"],
+        "matches": ["https://play.pocketcasts.com/*"],
         "js": ["commands.js"]
     }],
 


### PR DESCRIPTION
Pocket Casts has taken their new player out of beta, and as such this no longer works. It seems like @tobiasthyssen is not around anymore, so I would prefer it if you wouldn't mind updating this version so that users have an "actively maintained" version to choose from. 

From what I can tell, the beta player is completely gone now. This removes support for it and brings support for the current player.

I also threw a commit in here to open Pocket Casts if no tab is found. I'm happy to remove that if you would rather not have it in there.